### PR TITLE
Reversed names to Summoner

### DIFF
--- a/WebApi/Controllers/TestController.cs
+++ b/WebApi/Controllers/TestController.cs
@@ -5,20 +5,19 @@ using System.Net;
 using System.Net.Http;
 using System.Web.Http;
 using WebApi.Models;
+using WebApi.Models.SummonerByName;
 
 namespace WebApi.Controllers
 {
     public class TestController : ApiController
     {
         // GET api/<controller>
-        public ResultDto Get()
+        public Summoner Get()
         {
             var parser = new JsonParser();
-            parser.Parser("na", "lose is improve");
-            return new ResultDto
-            {
-                Data = "Success"
-            };
+
+            return parser.Parser("na", "lose is improve");
+            
         }
 
         // GET api/<controller>/5

--- a/WebApi/Models/JsonParser.cs
+++ b/WebApi/Models/JsonParser.cs
@@ -11,13 +11,14 @@ namespace WebApi.Models
 {
     public class JsonParser
     {
-        public void Parser(string region, string summonerName)
+        public Summoner Parser(string region, string summonerName)
         {
             using (var w = new HttpClient())
             {
                 var json = w.GetStringAsync($"https://na.api.pvp.net/api/lol/{region}/v1.4/summoner/by-name/{summonerName}?api_key=RGAPI-a231c9d7-98c8-436a-b77b-49bbec82462c").Result;
-                var r = JsonConvert.DeserializeObject<RootObject>(json);
-                Debug.WriteLine(r.loseisimprove.name);
+                var r = JsonConvert.DeserializeObject<Dictionary<string, Summoner>>(json);
+                return r.Values.First(); //zakładam, że jest tylko jeden summoner w dictionary, ale chuj wie, bo rito, może tu by trzeba ładniej zrobić
+
             }
         }
     }

--- a/WebApi/Models/SummonerByName/RootObject.cs
+++ b/WebApi/Models/SummonerByName/RootObject.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace WebApi.Models.SummonerByName
 {
     public class RootObject
     {
-        [JsonProperty("Loseisimprove")]
-        public Loseisimprove loseisimprove { get; set; }
+        public List<Summoner> Summoner { get; set; }
     }
 }

--- a/WebApi/Models/SummonerByName/Summoner.cs
+++ b/WebApi/Models/SummonerByName/Summoner.cs
@@ -7,17 +7,17 @@ using Newtonsoft.Json.Serialization;
 
 namespace WebApi.Models.SummonerByName
 {
-    public class Loseisimprove
+    public class Summoner
     {
         [JsonProperty("id")]
-        public int id { get; set; }
+        public int Id { get; set; }
         [JsonProperty("name")]
-        public string name { get; set; }
+        public string Name { get; set; }
         [JsonProperty("profileIconId")]
-        public int profileIconId { get; set; }
+        public int ProfileIconId { get; set; }
         [JsonProperty("revisionDate")]
-        public long revisionDate { get; set; }
+        public long RevisionDate { get; set; }
         [JsonProperty("summonerLevel")]
-        public int summonerLevel { get; set; }
+        public int SummonerLevel { get; set; }
     }
 }


### PR DESCRIPTION
Modified test controller to return Summoner instead of test dto
RootObject no longer requires attribute decoration
Naming convention in Summoner's properties
Returning Summoner from Parser
Parser now uses generic dictionary of Summoners, no longer bound to root object's property name